### PR TITLE
Improve portability

### DIFF
--- a/bin/apachehere
+++ b/bin/apachehere
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # apachehere
 #
 usage_exit() {


### PR DESCRIPTION
'bash' is installed at /usr/local/bin on some platform like
BSD distributions.
